### PR TITLE
depend on less specific package versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 		"class": "OomphInc\\ComposerInstallersExtender\\Plugin"
 	},
 	"require": {
-		"composer-plugin-api": "1.0.0",
-		"composer/installers": "1.0.22"
+		"composer-plugin-api": "^1.0",
+		"composer/installers": "~1.0.22"
 	}
 }


### PR DESCRIPTION
I tried your package and it wouldn't install with composer out of the box. It requires specific versions of its dependencies without the need for it.
This change will make it more flexible to install.
I tested it but you should have another look at it.

A release as 1.1 would be much appreciated!
