### PR TITLE
Add functionality to disable certain package (framework) types

### DIFF
--- a/src/Installer.php
+++ b/src/Installer.php
@@ -2,34 +2,37 @@
 
 namespace OomphInc\ComposerInstallersExtender;
 
-use Composer\Installer\LibraryInstaller;
-use Composer\Installers\Installer as ComposerInstaller;
+use Composer\Composer;
+use Composer\IO\IOInterface;
 use Composer\Package\PackageInterface;
 
-class Installer extends ComposerInstaller {
+class Installer extends \Composer\Installers\Installer {
 
+	// array of supported types
 	protected $packageTypes;
+	// instance of Composer\Installers\BaseInstaller used to get a path from extra
+	protected $installerHelper;
+
+	public function __construct( IOInterface $io, Composer $composer, array $packageTypes ) {
+		$this->packageTypes = $packageTypes;
+		// get an installer helper
+		$this->installerHelper = new InstallerHelper( null, $composer, $io );
+		parent::__construct( $io, $composer );
+	}
 
 	public function getInstallPath( PackageInterface $package ) {
-		$installer = new InstallerHelper( $package, $this->composer, $this->io );
-		$path = $installer->getInstallPath( $package, $package->getType() );
-		// if the path is false, use the default installer path instead
-		return $path !== false ? $path : LibraryInstaller::getInstallPath( $package );
+		$this->installerHelper->setPackage( $package );
+		try {
+			// see if we have an install path
+			return $this->installerHelper->getInstallPath( $package );
+		} catch ( \InvalidArgumentException $e ) {
+			// otherwise use the default (library) install path
+			return \Composer\Installer\LibraryInstaller::getInstallPath( $package );
+		}
 	}
 
 	public function supports( $packageType ) {
-		// grab the package types once
-		if ( !isset( $this->packageTypes ) ) {
-			$this->packageTypes = false;
-			if ( $this->composer->getPackage() ) {
-				// get data from the 'extra' field
-				$extra = $this->composer->getPackage()->getExtra();
-				if ( !empty( $extra['installer-types'] ) ) {
-					$this->packageTypes = (array) $extra['installer-types'];
-				}
-			}
-		}
-		return is_array( $this->packageTypes ) && in_array( $packageType, $this->packageTypes );
+		return in_array( $packageType, $this->packageTypes );
 	}
 
 }

--- a/src/InstallerHelper.php
+++ b/src/InstallerHelper.php
@@ -3,13 +3,16 @@
 namespace OomphInc\ComposerInstallersExtender;
 
 use Composer\Installers\BaseInstaller;
+use Composer\Package\PackageInterface;
 
 class InstallerHelper extends BaseInstaller {
 
-	function getLocations() {
-		// it will be looking for a key of FALSE, which evaluates to 0, i.e. the first element
-		// that element value being false signals the installer to use the default path
-		return [ false ];
+	/**
+	 * Set the package property so the same instance can be used for multiple packages.
+	 * @param PackageInterface $package
+	 */
+	function setPackage( PackageInterface $package ) {
+		$this->package = $package;
 	}
 
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -9,7 +9,11 @@ use Composer\Plugin\PluginInterface;
 class Plugin implements PluginInterface {
 
 	public function activate( Composer $composer, IOInterface $io ) {
-		$installer = new Installer( $io, $composer );
+		// check that we have package types
+		if ( !( $extra = $composer->getPackage()->getExtra() ) || empty( $extra['installer-types'] ) ) {
+			return;
+		}
+		$installer = new Installer( $io, $composer, (array) $extra['installer-types'] );
 		$composer->getInstallationManager()->addInstaller( $installer );
 	}
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -13,7 +13,39 @@ class Plugin implements PluginInterface {
 		if ( !( $extra = $composer->getPackage()->getExtra() ) || empty( $extra['installer-types'] ) ) {
 			return;
 		}
-		$installer = new Installer( $io, $composer, (array) $extra['installer-types'] );
+		$types = (array) $extra['installer-types'];
+		// default composer-installers frameworks can be disabled
+		$disable = array_filter( $types, function( $type ) {
+			return $type[0] === '!';
+		} );
+		// do we have any frameworks to disable?
+		if ( count( $disable ) ) {
+			// get the installation manager
+			$manager = $composer->getInstallationManager();
+			// use reflection to get all of the installers
+			$installers = new \ReflectionProperty( $manager, 'installers' );
+			$installers->setAccessible( true );
+			// find the composer-installers installer
+			foreach ( $installers->getValue( $manager ) as $installer ) {
+				if ( !( $installer instanceof \Composer\Installers\Installer ) ) {
+					continue;
+				}
+				// use reflection again to get access to the supported types (frameworks) array
+				$prop = new \ReflectionProperty( $installer, 'supportedTypes' );
+				$prop->setAccessible( true );
+				$frameworks = $prop->getValue( $installer );
+				// unset any disabled frameworks
+				foreach ( $disable as $framework ) {
+					unset( $frameworks[ substr( $framework, 1 ) ] );
+				}
+				// update the value
+				$prop->setValue( $installer, $frameworks );
+				break;
+			}
+			// remove disabled types from the new types
+			$types = array_diff( $types, $disable );
+		}
+		$installer = new Installer( $io, $composer, $types );
 		$composer->getInstallationManager()->addInstaller( $installer );
 	}
 


### PR DESCRIPTION
Allows you to specify framework types to disable in the `'installer-types'` property by prepending the framework name with a bang. There is no way to inform composer of a precedence for installers, so if `composer-installers` gets loaded first, it will claim any types that it supports, even if you have an alternate installer for one of those types. This is allows you to prevent `composer-installers` from claiming types that you wish to use a different installer for. The only way to do this is through reflection to identify the installer and modify the private property that defines all of the supported types.

This also modifies the logic of how we get `composer-installers` to handle additional types by catching an expected exception rather than (confusingly) overriding the `getLocations()` method to return a value of false and looking for that.
