### PR TITLE
Use less restrictive version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,6 @@
 	},
 	"require": {
 		"composer-plugin-api": "^1.0",
-		"composer/installers": "^1.1"
+		"composer/installers": "^1.0"
 	}
 }


### PR DESCRIPTION
...in case other dependencies require a more specific version that is <1.1 - this will allow the solver to still come back with a compatible set of packages
