### PR TITLE
Add support for composer 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
     },
     "require": {
         "php": ">=7.1",
-        "composer-plugin-api": "^1.0",
+        "composer-plugin-api": "^1.1 || ^2.0",
         "composer/installers": "^1.0"
     },
     "require-dev": {
-        "composer/composer": "^1.6",
+        "composer/composer": "^2.0",
         "phpunit/phpunit": "^7.2",
         "squizlabs/php_codesniffer": "^3.3"
     },
@@ -49,5 +49,7 @@
     },
     "extra": {
         "class": "OomphInc\\ComposerInstallersExtender\\Plugin"
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -23,14 +23,14 @@ class Plugin implements PluginInterface
     /**
      * {@inheritDoc}
      */
-    public function deactivate(Composer $composer, IOInterface $io)
+    public function deactivate(Composer $composer, IOInterface $io): void
     {
     }
 
     /**
      * {@inheritDoc}
      */
-    public function uninstall(Composer $composer, IOInterface $io)
+    public function uninstall(Composer $composer, IOInterface $io): void
     {
     }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -19,4 +19,18 @@ class Plugin implements PluginInterface
         $installer = new Installer($io, $composer);
         $composer->getInstallationManager()->addInstaller($installer);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+    }
 }


### PR DESCRIPTION
Fixes #21.

From what I see, there are no changes other than the addition of two extra methods. I needed to add `minimum-stability` because composer 2 is only alpha right now.