### PR TITLE
Add branch-alias to composer.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog][] and this project adheres to the
 
 ## [Unreleased]
 ### Added
+- Add `branch-alias` to `composer.json`
 
 ### Changed
 

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
     "extra": {
         "class": "OomphInc\\ComposerInstallersExtender\\Plugin",
         "branch-alias": {
-            "dev-master": "1.x-dev"
+            "dev-master": "2.x-dev"
         }
     },
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,10 @@
         "sort-packages": true
     },
     "extra": {
-        "class": "OomphInc\\ComposerInstallersExtender\\Plugin"
+        "class": "OomphInc\\ComposerInstallersExtender\\Plugin",
+        "branch-alias": {
+            "dev-master": "1.x-dev"
+        }
     },
     "minimum-stability": "dev",
     "prefer-stable": true


### PR DESCRIPTION
Per https://getcomposer.org/doc/articles/aliases.md#branch-alias, this would allow people with `"minimum-stability": "dev"` in their root composer.json to get the tip of this project's master branch if they have dependencies that require this project with a constraint of `"^1"` or similar. An example use-case for that is if someone is using Composer 2, and #22 exists on master but not in a tagged release yet.
