### PR TITLE
Fix plugin test

### DIFF
--- a/tests/src/PluginTest.php
+++ b/tests/src/PluginTest.php
@@ -30,6 +30,14 @@ class PluginTest extends TestCase
                     return null;
                 }
             });
+        $this->composer
+            ->method('getPackage')
+            ->willReturn(new class{
+                public function getExtra()
+                {
+                    return null;
+                }
+            });
 
         $this->io = $this->createMock(IOInterface::class);
     }


### PR DESCRIPTION
Installer constructor fails because current composer checks and tries to
remove disabled installers but ends up calling a method on the null
returned by the mock. This mocks up the new method call though this
could be prone to failures on future versions. The dangers of mocking
things you don't own.