### PR TITLE
allow composer/installers also in version 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=7.1",
         "composer-plugin-api": "^1.1 || ^2.0",
-        "composer/installers": "^1.0"
+        "composer/installers": "^1.0 || ^2.0"
     },
     "require-dev": {
         "composer/composer": "^2.0",


### PR DESCRIPTION
The dependecy composer/installers has update his supported types. Can we please also allow version 2.x?