### PR TITLE
Return an absolute path for the installed packages

### DIFF
--- a/src/Installers/Installer.php
+++ b/src/Installers/Installer.php
@@ -23,9 +23,10 @@ class Installer extends InstallerBase
     public function getInstallPath(PackageInterface $package): string
     {
         $installer = new CustomInstaller($package, $this->composer, $this->io);
+        $baseDir = rtrim(rtrim($this->vendorDir ?: '', 'vendor'),'/');
         $path = $installer->getInstallPath($package, $package->getType());
 
-        return $path ?: LibraryInstaller::getInstallPath($package);
+        return $path ? $baseDir . '/' . $path : LibraryInstaller::getInstallPath($package);
     }
 
     /**


### PR DESCRIPTION
Return an absolute composer installer path instead of an relative.
If this composer installer package is used in unit tests which mocks composer directories, this will never work because the relative path is used from the main script file instead of the relative path to the composer.json